### PR TITLE
SSHトンネル起動時の高CPU使用率を修正

### DIFF
--- a/Tunnelas.xcodeproj/project.pbxproj
+++ b/Tunnelas.xcodeproj/project.pbxproj
@@ -10,17 +10,20 @@
 		11E4C9CBA90E7356543D46FF /* TunnelasInfra.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D957637256445C6C20577942 /* TunnelasInfra.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		1B6A4BBB183483D1A2F7C12B /* RuleDefinitions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39A6401C5C8DD6F754D07AB3 /* RuleDefinitions.swift */; };
 		21029D7426E512672433D914 /* TunnelasApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = B37A598710018DAA5EC21EF8 /* TunnelasApp.swift */; };
+		220746425F64306F329DEA54 /* TunnelasInfra.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D957637256445C6C20577942 /* TunnelasInfra.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		25F48BDE2174FDEB3E7F04FB /* SystemCommandBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB8678D71FC18DDDA66886EB /* SystemCommandBuilder.swift */; };
 		313257C6EAFF4FCAAF662BD1 /* TunnelRuntimeStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB15F85A3E8A4FB6547FF655 /* TunnelRuntimeStoreTests.swift */; };
 		35B0A0FA27CDFFB022532010 /* SystemSleepWakeObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F4BE7156ED22D6507FA751E /* SystemSleepWakeObserver.swift */; };
 		414FDE5F05F98E43D98683BA /* TunnelasCore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 1F2BE063330D42012C38B055 /* TunnelasCore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		53E9F660455D1D8D6417EE5F /* RuntimeTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A18A3A6717C4E66A426F4CD /* RuntimeTypes.swift */; };
 		56C1067C20BE5E8FBD001FA7 /* ConfigurationValidation.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF7C4AC2E241443446D65F86 /* ConfigurationValidation.swift */; };
+		65D25D3486611006479F95EB /* SystemProcessRunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9886AF07550C4912F68BF81 /* SystemProcessRunnerTests.swift */; };
 		6C134D5E0CEF8138816B8E76 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FC72BF2B0AD310288099857 /* SettingsView.swift */; };
 		769A4B2C9AC19E56B552BDDF /* TunnelRuntimeStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C9F80AC2CA0539F66BF47EA /* TunnelRuntimeStore.swift */; };
 		9322745A39524B79952C4484 /* TunnelasCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1F2BE063330D42012C38B055 /* TunnelasCore.framework */; };
 		99E57B1BDE15EF114A19B1E4 /* TunnelasCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1F2BE063330D42012C38B055 /* TunnelasCore.framework */; };
 		9E74CA13FA2928242FBCB798 /* LogWindowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F9A78BC7C712601B2CA0DAF /* LogWindowView.swift */; };
+		A08E0916B7F71EC3B188B741 /* TunnelasInfra.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D957637256445C6C20577942 /* TunnelasInfra.framework */; };
 		A50DA7AD02CA4A36DE9F8897 /* TunnelasCore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 1F2BE063330D42012C38B055 /* TunnelasCore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		AD27FA3A2915685BDBD9638A /* TunnelasInfra.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D957637256445C6C20577942 /* TunnelasInfra.framework */; };
 		B0ACF6B20BA82A2FB3FF41F6 /* AppModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88FC8D2AE52E3E35073EFDD6 /* AppModel.swift */; };
@@ -49,6 +52,13 @@
 			remoteGlobalIDString = 3485C0447DD51AF3AA1D981B;
 			remoteInfo = TunnelasCore;
 		};
+		59E4FD2801EDB3D061CEDA98 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 466DE0F35964327A6DD44E41 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 320539D24478658FABC9525B;
+			remoteInfo = TunnelasInfra;
+		};
 		99083529D040756D4C16DD08 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 466DE0F35964327A6DD44E41 /* Project object */;
@@ -73,6 +83,7 @@
 			dstSubfolderSpec = 10;
 			files = (
 				A50DA7AD02CA4A36DE9F8897 /* TunnelasCore.framework in Embed Frameworks */,
+				220746425F64306F329DEA54 /* TunnelasInfra.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -112,6 +123,7 @@
 		D90044E4A5461D37C3B20536 /* SystemProcessRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemProcessRunner.swift; sourceTree = "<group>"; };
 		D957637256445C6C20577942 /* TunnelasInfra.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = TunnelasInfra.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E2D12102B97CDFDB73821761 /* ConfigurationModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationModels.swift; sourceTree = "<group>"; };
+		E9886AF07550C4912F68BF81 /* SystemProcessRunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemProcessRunnerTests.swift; sourceTree = "<group>"; };
 		EB15F85A3E8A4FB6547FF655 /* TunnelRuntimeStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TunnelRuntimeStoreTests.swift; sourceTree = "<group>"; };
 		F8F6CD26D6A6070DA670D9B7 /* TunnelasCoreTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TunnelasCoreTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -122,6 +134,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				9322745A39524B79952C4484 /* TunnelasCore.framework in Frameworks */,
+				A08E0916B7F71EC3B188B741 /* TunnelasInfra.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -195,6 +208,7 @@
 			isa = PBXGroup;
 			children = (
 				2D470C6B2D8CFF1CB36DFE21 /* ConfigurationValidatorTests.swift */,
+				E9886AF07550C4912F68BF81 /* SystemProcessRunnerTests.swift */,
 				EB15F85A3E8A4FB6547FF655 /* TunnelRuntimeStoreTests.swift */,
 			);
 			path = TunnelasCoreTests;
@@ -228,6 +242,7 @@
 			);
 			dependencies = (
 				FF04BACC25A77FECDBC42854 /* PBXTargetDependency */,
+				DF847AAC29B5E32092A4399F /* PBXTargetDependency */,
 			);
 			name = TunnelasCoreTests;
 			packageProductDependencies = (
@@ -355,6 +370,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				F8DD6A9878A065647D385BE1 /* ConfigurationValidatorTests.swift in Sources */,
+				65D25D3486611006479F95EB /* SystemProcessRunnerTests.swift in Sources */,
 				313257C6EAFF4FCAAF662BD1 /* TunnelRuntimeStoreTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -397,6 +413,11 @@
 			isa = PBXTargetDependency;
 			target = 3485C0447DD51AF3AA1D981B /* TunnelasCore */;
 			targetProxy = 99083529D040756D4C16DD08 /* PBXContainerItemProxy */;
+		};
+		DF847AAC29B5E32092A4399F /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 320539D24478658FABC9525B /* TunnelasInfra */;
+			targetProxy = 59E4FD2801EDB3D061CEDA98 /* PBXContainerItemProxy */;
 		};
 		FB7471C62727A5A9370B6E05 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;

--- a/TunnelasCoreTests/SystemProcessRunnerTests.swift
+++ b/TunnelasCoreTests/SystemProcessRunnerTests.swift
@@ -1,0 +1,92 @@
+import Foundation
+import Testing
+@testable import TunnelasInfra
+
+struct SystemProcessRunnerTests {
+    @Test
+    func pipeReadMonitorDoesNotEmitForIdleOpenPipe() async throws {
+        let pipe = Pipe()
+        let probe = PipeReadMonitorProbe()
+        let monitor = PipeReadMonitor(
+            fileHandle: pipe.fileHandleForReading,
+            onData: { data in
+                Task { await probe.record(data) }
+            },
+            onEOF: {
+                Task { await probe.finish() }
+            }
+        )
+
+        defer {
+            monitor.cancel()
+            pipe.fileHandleForWriting.closeFile()
+        }
+
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        let snapshot = await probe.snapshot()
+        #expect(snapshot.chunks.isEmpty)
+        #expect(snapshot.didFinish == false)
+    }
+
+    @Test
+    func pipeReadMonitorEmitsDataAndFinishesAfterWriterCloses() async throws {
+        let pipe = Pipe()
+        let probe = PipeReadMonitorProbe()
+        let monitor = PipeReadMonitor(
+            fileHandle: pipe.fileHandleForReading,
+            onData: { data in
+                Task { await probe.record(data) }
+            },
+            onEOF: {
+                Task { await probe.finish() }
+            }
+        )
+
+        defer {
+            monitor.cancel()
+        }
+
+        pipe.fileHandleForWriting.write(Data("hello".utf8))
+        pipe.fileHandleForWriting.closeFile()
+
+        let didFinish = await probe.waitUntilFinished(timeoutNanoseconds: 1_000_000_000)
+        let snapshot = await probe.snapshot()
+
+        #expect(didFinish == true)
+        #expect(String(decoding: snapshot.chunks.joined(), as: UTF8.self) == "hello")
+    }
+}
+
+private actor PipeReadMonitorProbe {
+    struct Snapshot {
+        let chunks: [Data]
+        let didFinish: Bool
+    }
+
+    private var chunks: [Data] = []
+    private var didFinish = false
+
+    func record(_ data: Data) {
+        chunks.append(data)
+    }
+
+    func finish() {
+        didFinish = true
+    }
+
+    func snapshot() -> Snapshot {
+        Snapshot(chunks: chunks, didFinish: didFinish)
+    }
+
+    func waitUntilFinished(timeoutNanoseconds: UInt64) async -> Bool {
+        let deadline = DispatchTime.now().uptimeNanoseconds + timeoutNanoseconds
+        while !didFinish {
+            if DispatchTime.now().uptimeNanoseconds >= deadline {
+                return false
+            }
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+        return true
+    }
+}

--- a/TunnelasInfra/SystemProcessRunner.swift
+++ b/TunnelasInfra/SystemProcessRunner.swift
@@ -18,26 +18,30 @@ public struct SystemProcessRunner: ProcessRunning {
         process.standardOutput = stdoutPipe
         process.standardError = stderrPipe
 
-        stdoutPipe.fileHandleForReading.readabilityHandler = { handle in
-            let data = handle.availableData
-            guard !data.isEmpty, let text = String(data: data, encoding: .utf8) else { return }
+        let stdoutMonitor = PipeReadMonitor(fileHandle: stdoutPipe.fileHandleForReading) { data in
+            guard let text = String(data: data, encoding: .utf8), !text.isEmpty else { return }
             emitter.yield(.stdout(text))
         }
 
-        stderrPipe.fileHandleForReading.readabilityHandler = { handle in
-            let data = handle.availableData
-            guard !data.isEmpty, let text = String(data: data, encoding: .utf8) else { return }
+        let stderrMonitor = PipeReadMonitor(fileHandle: stderrPipe.fileHandleForReading) { data in
+            guard let text = String(data: data, encoding: .utf8), !text.isEmpty else { return }
             emitter.yield(.stderr(text))
         }
 
         process.terminationHandler = { terminatedProcess in
-            stdoutPipe.fileHandleForReading.readabilityHandler = nil
-            stderrPipe.fileHandleForReading.readabilityHandler = nil
+            stdoutMonitor.cancel()
+            stderrMonitor.cancel()
             emitter.yield(.terminated(terminatedProcess.terminationStatus))
             emitter.finish()
         }
 
-        try process.run()
+        do {
+            try process.run()
+        } catch {
+            stdoutMonitor.cancel()
+            stderrMonitor.cancel()
+            throw error
+        }
 
         return ManagedProcessSession(
             processIdentifier: process.processIdentifier,
@@ -68,3 +72,56 @@ private final class ProcessEmitter: @unchecked Sendable {
     }
 }
 
+final class PipeReadMonitor: @unchecked Sendable {
+    private static let queue = DispatchQueue(
+        label: "com.ktutumi.tunnelas.pipe-read-monitor",
+        qos: .utility,
+        attributes: .concurrent
+    )
+
+    private let fileHandle: FileHandle
+    private let source: DispatchSourceRead
+    private let onData: @Sendable (Data) -> Void
+    private let onEOF: @Sendable () -> Void
+    private let stateLock = NSLock()
+    private var isCancelled = false
+
+    init(
+        fileHandle: FileHandle,
+        queue: DispatchQueue = PipeReadMonitor.queue,
+        onData: @escaping @Sendable (Data) -> Void,
+        onEOF: @escaping @Sendable () -> Void = {}
+    ) {
+        self.fileHandle = fileHandle
+        self.onData = onData
+        self.onEOF = onEOF
+        self.source = DispatchSource.makeReadSource(fileDescriptor: fileHandle.fileDescriptor, queue: queue)
+        source.setEventHandler { [weak self] in
+            self?.handleReadableEvent()
+        }
+        source.resume()
+    }
+
+    func cancel() {
+        stateLock.lock()
+        let shouldCancel = !isCancelled
+        isCancelled = true
+        stateLock.unlock()
+
+        guard shouldCancel else { return }
+        source.cancel()
+    }
+
+    private func handleReadableEvent() {
+        let byteCount = max(Int(source.data), 1)
+        let data = (try? fileHandle.read(upToCount: byteCount)) ?? Data()
+
+        guard !data.isEmpty else {
+            cancel()
+            onEOF()
+            return
+        }
+
+        onData(data)
+    }
+}

--- a/_docs/ai/thinking/20260309_010047_claude_ssh_cpu_investigation.md
+++ b/_docs/ai/thinking/20260309_010047_claude_ssh_cpu_investigation.md
@@ -1,0 +1,9 @@
+# SSH トンネル高 CPU 調査
+
+- 症状: アプリ起動後、SSH トンネルを 1 本起動するごとに CPU 使用率が約 100% 増える。
+- 調査対象: `TunnelasCore/TunnelRuntimeStore.swift` と `TunnelasInfra/SystemProcessRunner.swift`。
+- 結論: 根本原因は `SystemProcessRunner` の `Pipe.fileHandleForReading.readabilityHandler`。
+- 理由: stdout / stderr の `availableData` が 0 バイトでも継続的に callback されるため、出力がない長寿命プロセスで busy loop になる。
+- 補助検証: `Process` で `/bin/sleep 1` を起動し stdout/stderr に `Pipe` を接続したところ、約 1.2 秒で stdout 131107 回、stderr 131685 回 callback が発生した。
+- 推定影響: `ssh -N` のような通常ほぼ無出力の常駐プロセスで、トンネル 1 本ごとに 2 本の pipe 監視が常時スピンし、CPU 使用率が線形に増える。
+- 補足: `TunnelRuntimeStore` 側の `waitForTermination` ポーリングは停止時のみ実行されるため、常時高 CPU の主因ではない。

--- a/_docs/ai/thinking/20260309_010414_claude_pipe_read_monitor_fix.md
+++ b/_docs/ai/thinking/20260309_010414_claude_pipe_read_monitor_fix.md
@@ -1,0 +1,7 @@
+# PipeReadMonitor への置き換え
+
+- 背景: `Pipe.fileHandleForReading.readabilityHandler` が 0 バイト `availableData` でも連続発火し、無出力プロセスで CPU を消費する。
+- 方針: `SystemProcessRunner` の監視を `DispatchSourceRead` ベースに置き換える。
+- 理由: 読み取り可能イベントが来たときだけ `read(upToCount:)` を実行でき、アイドル状態の pipe で busy loop しない。
+- 実装: `TunnelasInfra/SystemProcessRunner.swift` に内部 `PipeReadMonitor` を追加し、stdout/stderr を同一方式で監視する。
+- テスト: `TunnelasCoreTests/SystemProcessRunnerTests.swift` で、(1) writer が開いたまま無出力の pipe ではイベントが発火しないこと、(2) 書き込み後に writer を閉じるとデータ取得と EOF 完了が起きること、を確認した。

--- a/project.yml
+++ b/project.yml
@@ -57,6 +57,7 @@ targets:
       - TunnelasCoreTests
     dependencies:
       - target: TunnelasCore
+      - target: TunnelasInfra
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.ktutumi.tunnelas.tests
@@ -69,4 +70,3 @@ schemes:
     test:
       targets:
         - TunnelasCoreTests
-

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -34,11 +34,11 @@
 
 ## Current Task
 
-### Issue #9 メニュー項目への接続ステータス表示追加
+### SSH トンネル高 CPU 修正
 
-- [x] グループ項目に接続状態を示す記号を表示する
-- [x] ルール項目に接続状態を示す記号を表示する
-- [x] `running` / `starting` / `error` / `stopped` の 4 状態を識別できるようにする
+- [x] SSH トンネル起動時に CPU 使用率が上昇する経路を特定する
+- [x] 無出力プロセスでスピンしない監視方式のテストを追加する
+- [x] `SystemProcessRunner` の stdout / stderr 監視を修正する
 - [x] `xcodebuild test -scheme Tunnelas -project Tunnelas.xcodeproj -destination 'platform=macOS'` を通す
 
 ## Review Notes
@@ -58,3 +58,5 @@
 - 2026-03-08 21:55 JST にメニューのグループ項目とルール項目へ状態記号とアクセシビリティラベルを追加し、`xcodebuild test -scheme Tunnelas -project Tunnelas.xcodeproj -destination 'platform=macOS'` を再実行して 17 テストが成功した。
 - 2026-03-08 23:41 JST に、サブメニュー項目のアイコンが実メニューに表示されない問題を修正し、項目タイトルに状態文字列を含める形へ切り替えた。`xcodebuild test -scheme Tunnelas -project Tunnelas.xcodeproj -destination 'platform=macOS'` を再実行して 17 テストが成功した。
 - 2026-03-08 23:51 JST に、メニュー項目の状態表示を Unicode 記号 `● / ◐ / ▲ / ○` に変更し、行頭へ配置した。`xcodebuild test -scheme Tunnelas -project Tunnelas.xcodeproj -destination 'platform=macOS'` を再実行して 17 テストが成功した。
+- 2026-03-09 01:00 JST に SSH トンネル起動時の高 CPU を調査し、`SystemProcessRunner` の `Pipe.fileHandleForReading.readabilityHandler` が 0 バイト `availableData` を継続的に受け取ってスピンすることを補助検証で確認した。`/bin/sleep 1` に対しても stdout/stderr それぞれ約 13 万回のコールバックが発生した。
+- 2026-03-09 01:04 JST に `SystemProcessRunner` の stdout/stderr 監視を `DispatchSourceRead` ベースの `PipeReadMonitor` に置き換え、アイドル状態の pipe でイベントが発火しないことをテスト追加で固定した。`xcodebuild test -scheme Tunnelas -project Tunnelas.xcodeproj -destination 'platform=macOS'` は 19 テスト成功で完了した。


### PR DESCRIPTION
## 概要
- `SystemProcessRunner` の stdout / stderr 監視を `DispatchSourceRead` ベースの `PipeReadMonitor` に置き換えました
- 無出力の pipe がアイドル状態でもイベントを発火しないことを確認するテストを追加しました
- 調査結果と検証結果を `tasks/todo.md` と thinking ドキュメントに記録しました

## テスト
- `xcodebuild test -scheme Tunnelas -project Tunnelas.xcodeproj -destination 'platform=macOS'`

Closes #11